### PR TITLE
Adding core animation to improve performance (and also fade between colors)

### DIFF
--- a/ColorClockSaver.xcodeproj/project.pbxproj
+++ b/ColorClockSaver.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		39D892411EF4BEBD0063F53D /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D892401EF4BEBD0063F53D /* Date.swift */; };
 		39D892421EF4BEBF0063F53D /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D892401EF4BEBD0063F53D /* Date.swift */; };
 		39D984771EF40F3E006E0617 /* ColorCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D984761EF40F3E006E0617 /* ColorCodeView.swift */; };
+		39E88BC41EFD92050014F7EF /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC31EFD92050014F7EF /* BackgroundView.swift */; };
+		39E88BC51EFD92890014F7EF /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC31EFD92050014F7EF /* BackgroundView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +40,7 @@
 		39BF17AE1EF1D8B500BB834B /* TimeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeView.swift; sourceTree = "<group>"; };
 		39D892401EF4BEBD0063F53D /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Date.swift; path = ColorClockSaver/Date.swift; sourceTree = "<group>"; };
 		39D984761EF40F3E006E0617 /* ColorCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorCodeView.swift; sourceTree = "<group>"; };
+		39E88BC31EFD92050014F7EF /* BackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				39BF177D1EF1BA0600BB834B /* MainView.swift */,
+				39E88BC31EFD92050014F7EF /* BackgroundView.swift */,
 				39BF17AE1EF1D8B500BB834B /* TimeView.swift */,
 				39D984761EF40F3E006E0617 /* ColorCodeView.swift */,
 				39B2D02E1EF59B190068BB3F /* Fonts.swift */,
@@ -233,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39E88BC41EFD92050014F7EF /* BackgroundView.swift in Sources */,
 				39D984771EF40F3E006E0617 /* ColorCodeView.swift in Sources */,
 				39B2D02F1EF59B190068BB3F /* Fonts.swift in Sources */,
 				39D892411EF4BEBD0063F53D /* Date.swift in Sources */,
@@ -248,6 +253,7 @@
 				39BF17A61EF1C2DA00BB834B /* MainView.swift in Sources */,
 				39D892421EF4BEBF0063F53D /* Date.swift in Sources */,
 				39BF179A1EF1C2D400BB834B /* AppDelegate.swift in Sources */,
+				39E88BC51EFD92890014F7EF /* BackgroundView.swift in Sources */,
 				39BF17B01EF1D8B800BB834B /* TimeView.swift in Sources */,
 				39B2D0301EF59B190068BB3F /* Fonts.swift in Sources */,
 				39D8923F1EF48C1D0063F53D /* ColorCodeView.swift in Sources */,

--- a/ColorClockSaver.xcodeproj/project.pbxproj
+++ b/ColorClockSaver.xcodeproj/project.pbxproj
@@ -77,10 +77,10 @@
 		39BF17661EF1B98E00BB834B = {
 			isa = PBXGroup;
 			children = (
-				3988956C1EF6E32E0006DD3C /* Extensions */,
-				39B2D0271EF5912C0068BB3F /* Assets */,
 				39BF17721EF1B98E00BB834B /* ColorClockSaver */,
 				39BF17981EF1C2D400BB834B /* Preview */,
+				39B2D0271EF5912C0068BB3F /* Assets */,
+				3988956C1EF6E32E0006DD3C /* Extensions */,
 				39BF17711EF1B98E00BB834B /* Products */,
 			);
 			sourceTree = "<group>";

--- a/ColorClockSaver/BackgroundView.swift
+++ b/ColorClockSaver/BackgroundView.swift
@@ -12,6 +12,7 @@ class BackgroundView: NSView {
   }
 
   func setup() {
+    wantsLayer = true
     if let layer = layer {
       let date = Date()
       layer.backgroundColor = date.asColor().cgColor

--- a/ColorClockSaver/BackgroundView.swift
+++ b/ColorClockSaver/BackgroundView.swift
@@ -1,0 +1,31 @@
+import Cocoa
+
+class BackgroundView: NSView {
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    setup()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setup()
+  }
+
+  func setup() {
+    if let layer = layer {
+      let date = Date()
+      layer.backgroundColor = date.asColor().cgColor
+    }
+  }
+
+  func update() {
+    let date = Date()
+    let newColor = date.asColor().cgColor
+    if let layer = layer {
+      let fade = CATransition()
+      fade.duration = 0.3
+      layer.add(fade, forKey: "transition")
+      layer.backgroundColor = newColor
+    }
+  }
+}

--- a/ColorClockSaver/Fonts.swift
+++ b/ColorClockSaver/Fonts.swift
@@ -14,6 +14,8 @@ class Fonts {
 
     var error: Unmanaged<CFError>? = nil
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error)
-    NSLog(String(describing: error))
+    if error != nil {
+      NSLog(String(describing: error))
+    }
   }
 }

--- a/ColorClockSaver/MainView.swift
+++ b/ColorClockSaver/MainView.swift
@@ -6,6 +6,7 @@ class MainView: ScreenSaverView {
   let colorCodeView = ColorCodeView()
 
   override func viewDidMoveToWindow() {
+    animationTimeInterval = 1
     Fonts.load(fontName: Fonts.timeFont, extension: "ttf")
     layoutViews()
     timeView.resizeFont(for: bounds.size)

--- a/ColorClockSaver/MainView.swift
+++ b/ColorClockSaver/MainView.swift
@@ -4,7 +4,6 @@ class MainView: ScreenSaverView {
   let wrapperView = NSStackView()
   let timeView = TimeView()
   let colorCodeView = ColorCodeView()
-  var currentBackground = Date().asColor().cgColor
 
   override func viewDidMoveToWindow() {
     wantsLayer = true
@@ -35,17 +34,17 @@ class MainView: ScreenSaverView {
     wrapperView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
   }
 
+  override func draw(_ rect: NSRect) {}
+
   override func animateOneFrame() {
     let date = Date()
     let newColor = date.asColor().cgColor
-    let animation = CABasicAnimation(keyPath: "backgroundColor")
-    animation.fromValue = currentBackground
-    animation.toValue = newColor
-    animation.duration = 1
 
     if let layer = layer {
-      layer.add(animation, forKey: "backgroundColor")
-      currentBackground = newColor
+      let fade = CATransition()
+      fade.duration = 0.1
+      layer.add(fade, forKey: "transition")
+      layer.backgroundColor = newColor
     }
     timeView.update()
     colorCodeView.update()

--- a/ColorClockSaver/MainView.swift
+++ b/ColorClockSaver/MainView.swift
@@ -4,8 +4,14 @@ class MainView: ScreenSaverView {
   let wrapperView = NSStackView()
   let timeView = TimeView()
   let colorCodeView = ColorCodeView()
+  var currentBackground = Date().asColor().cgColor
 
   override func viewDidMoveToWindow() {
+    wantsLayer = true
+    if let layer = layer {
+      let date = Date()
+      layer.backgroundColor = date.asColor().cgColor
+    }
     animationTimeInterval = 1
     Fonts.load(fontName: Fonts.timeFont, extension: "ttf")
     layoutViews()
@@ -29,18 +35,20 @@ class MainView: ScreenSaverView {
     wrapperView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
   }
 
-  override func draw(_ rect: NSRect) {
+  override func animateOneFrame() {
     let date = Date()
-    let startingColor = date.asColor()
-    let endingColor = date.asDarkenedColor()
-    if let gradient = NSGradient(starting: startingColor, ending: endingColor) {
-      gradient.draw(in: rect, relativeCenterPosition: NSPoint.zero)
+    let newColor = date.asColor().cgColor
+    let animation = CABasicAnimation(keyPath: "backgroundColor")
+    animation.fromValue = currentBackground
+    animation.toValue = newColor
+    animation.duration = 1
+
+    if let layer = layer {
+      layer.add(animation, forKey: "backgroundColor")
+      currentBackground = newColor
     }
     timeView.update()
     colorCodeView.update()
-  }
-
-  override func animateOneFrame() {
     setNeedsDisplay(bounds)
   }
 }

--- a/ColorClockSaver/MainView.swift
+++ b/ColorClockSaver/MainView.swift
@@ -1,16 +1,13 @@
 import ScreenSaver
 
 class MainView: ScreenSaverView {
+  let backgroundView = BackgroundView()
   let wrapperView = NSStackView()
   let timeView = TimeView()
   let colorCodeView = ColorCodeView()
 
   override func viewDidMoveToWindow() {
     wantsLayer = true
-    if let layer = layer {
-      let date = Date()
-      layer.backgroundColor = date.asColor().cgColor
-    }
     animationTimeInterval = 1
     Fonts.load(fontName: Fonts.timeFont, extension: "ttf")
     layoutViews()
@@ -19,6 +16,14 @@ class MainView: ScreenSaverView {
   }
 
   func layoutViews() {
+    addSubview(backgroundView)
+    backgroundView.translatesAutoresizingMaskIntoConstraints = false
+
+    backgroundView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+    backgroundView.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
+    backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+    backgroundView.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+
     wrapperView.frame = frame
     wrapperView.alignment = .centerX
     wrapperView.orientation = .vertical
@@ -37,15 +42,7 @@ class MainView: ScreenSaverView {
   override func draw(_ rect: NSRect) {}
 
   override func animateOneFrame() {
-    let date = Date()
-    let newColor = date.asColor().cgColor
-
-    if let layer = layer {
-      let fade = CATransition()
-      fade.duration = 0.1
-      layer.add(fade, forKey: "transition")
-      layer.backgroundColor = newColor
-    }
+    backgroundView.update()
     timeView.update()
     colorCodeView.update()
     setNeedsDisplay(bounds)


### PR DESCRIPTION
Broadly, this makes two major changes. The first is very simple: change the `animationTimeInterval` to 1 which only updates the view once per second. This greatly limits the number of times I was drawing a frame that didn't change.

The second is more substantial: fade between each color. This is most noticeable when the time changes to a new minute or hour. I tried a few different variations of this, starting with a [CABasicAnimation](https://developer.apple.com/documentation/quartzcore/cabasicanimation) but after a few bits of strange behavior ended up using a [CATransition](https://developer.apple.com/documentation/quartzcore/catransition).

This had the side effect of needing to make the background view a separate view instead of just using the background color of the MainView. Otherwise, the transition code would also apply to the time and color code text. This ended up making most of the code cleaner anyway so win-win.