### PR TITLE
Change text color to be visible on the ever-changing background color

### DIFF
--- a/ColorClockSaver.xcodeproj/project.pbxproj
+++ b/ColorClockSaver.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		39D984771EF40F3E006E0617 /* ColorCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D984761EF40F3E006E0617 /* ColorCodeView.swift */; };
 		39E88BC41EFD92050014F7EF /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC31EFD92050014F7EF /* BackgroundView.swift */; };
 		39E88BC51EFD92890014F7EF /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC31EFD92050014F7EF /* BackgroundView.swift */; };
+		39E88BC71EFDEC390014F7EF /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC61EFDEC390014F7EF /* NSColor.swift */; };
+		39E88BC81EFDF3060014F7EF /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC61EFDEC390014F7EF /* NSColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,7 @@
 		39D892401EF4BEBD0063F53D /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Date.swift; path = ColorClockSaver/Date.swift; sourceTree = "<group>"; };
 		39D984761EF40F3E006E0617 /* ColorCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorCodeView.swift; sourceTree = "<group>"; };
 		39E88BC31EFD92050014F7EF /* BackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
+		39E88BC61EFDEC390014F7EF /* NSColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +68,7 @@
 			isa = PBXGroup;
 			children = (
 				39D892401EF4BEBD0063F53D /* Date.swift */,
+				39E88BC61EFDEC390014F7EF /* NSColor.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -241,6 +245,7 @@
 				39D984771EF40F3E006E0617 /* ColorCodeView.swift in Sources */,
 				39B2D02F1EF59B190068BB3F /* Fonts.swift in Sources */,
 				39D892411EF4BEBD0063F53D /* Date.swift in Sources */,
+				39E88BC71EFDEC390014F7EF /* NSColor.swift in Sources */,
 				39BF177E1EF1BA0600BB834B /* MainView.swift in Sources */,
 				39BF17AF1EF1D8B500BB834B /* TimeView.swift in Sources */,
 			);
@@ -250,6 +255,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39E88BC81EFDF3060014F7EF /* NSColor.swift in Sources */,
 				39BF17A61EF1C2DA00BB834B /* MainView.swift in Sources */,
 				39D892421EF4BEBF0063F53D /* Date.swift in Sources */,
 				39BF179A1EF1C2D400BB834B /* AppDelegate.swift in Sources */,

--- a/ColorClockSaver.xcodeproj/project.pbxproj
+++ b/ColorClockSaver.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		39E88BC51EFD92890014F7EF /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC31EFD92050014F7EF /* BackgroundView.swift */; };
 		39E88BC71EFDEC390014F7EF /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC61EFDEC390014F7EF /* NSColor.swift */; };
 		39E88BC81EFDF3060014F7EF /* NSColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E88BC61EFDEC390014F7EF /* NSColor.swift */; };
+		39EA84F11F11A7B1008E1F7E /* LabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EA84F01F11A7B1008E1F7E /* LabelView.swift */; };
+		39EA84F21F11A94C008E1F7E /* LabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EA84F01F11A7B1008E1F7E /* LabelView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,7 @@
 		39D984761EF40F3E006E0617 /* ColorCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorCodeView.swift; sourceTree = "<group>"; };
 		39E88BC31EFD92050014F7EF /* BackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
 		39E88BC61EFDEC390014F7EF /* NSColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSColor.swift; sourceTree = "<group>"; };
+		39EA84F01F11A7B1008E1F7E /* LabelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +109,7 @@
 			children = (
 				39BF177D1EF1BA0600BB834B /* MainView.swift */,
 				39E88BC31EFD92050014F7EF /* BackgroundView.swift */,
+				39EA84F01F11A7B1008E1F7E /* LabelView.swift */,
 				39BF17AE1EF1D8B500BB834B /* TimeView.swift */,
 				39D984761EF40F3E006E0617 /* ColorCodeView.swift */,
 				39B2D02E1EF59B190068BB3F /* Fonts.swift */,
@@ -243,6 +247,7 @@
 			files = (
 				39E88BC41EFD92050014F7EF /* BackgroundView.swift in Sources */,
 				39D984771EF40F3E006E0617 /* ColorCodeView.swift in Sources */,
+				39EA84F11F11A7B1008E1F7E /* LabelView.swift in Sources */,
 				39B2D02F1EF59B190068BB3F /* Fonts.swift in Sources */,
 				39D892411EF4BEBD0063F53D /* Date.swift in Sources */,
 				39E88BC71EFDEC390014F7EF /* NSColor.swift in Sources */,
@@ -257,6 +262,7 @@
 			files = (
 				39E88BC81EFDF3060014F7EF /* NSColor.swift in Sources */,
 				39BF17A61EF1C2DA00BB834B /* MainView.swift in Sources */,
+				39EA84F21F11A94C008E1F7E /* LabelView.swift in Sources */,
 				39D892421EF4BEBF0063F53D /* Date.swift in Sources */,
 				39BF179A1EF1C2D400BB834B /* AppDelegate.swift in Sources */,
 				39E88BC51EFD92890014F7EF /* BackgroundView.swift in Sources */,

--- a/ColorClockSaver/ColorCodeView.swift
+++ b/ColorClockSaver/ColorCodeView.swift
@@ -23,15 +23,28 @@ class ColorCodeView: NSTextField {
     let date = Date()
     stringValue = date.asHexColorString()
 
-    if date.asColor().isLight {
-      textColor = .black
-    } else {
-      textColor = .white
-    }
+    fade(to: date.asColor().appropriateBlackOrWhite())
   }
 
   func resizeFont(for size: NSSize) {
     let newFontSize = size.width * 0.0212
     font = NSFont(name: Fonts.colorCodeFont, size: newFontSize)
+  }
+
+  func fade(to toColor: NSColor) {
+    guard let textColor = textColor else { return }
+    var stepCount: CGFloat = 1
+    let fromColor = textColor
+
+    Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true) { (timer) in
+      let fraction = stepCount / CGFloat(20)
+
+      if fraction >= 1 {
+        timer.invalidate()
+      }
+      self.textColor = fromColor.blended(withFraction: CGFloat(fraction),
+                                         of: toColor)
+      stepCount += 1
+    }
   }
 }

--- a/ColorClockSaver/ColorCodeView.swift
+++ b/ColorClockSaver/ColorCodeView.swift
@@ -8,6 +8,7 @@ class ColorCodeView: LabelView {
     isEditable = false
     font = NSFont(name: Fonts.colorCodeFont, size: 0)
     backgroundWasLight = Date().asColor().isLight
+    textColor = Date().asColor().appropriateBlackOrWhite()
   }
 
   func update() {

--- a/ColorClockSaver/ColorCodeView.swift
+++ b/ColorClockSaver/ColorCodeView.swift
@@ -1,50 +1,28 @@
 import Cocoa
 
-class ColorCodeView: NSTextField {
-  override init(frame frameRect: NSRect) {
-    super.init(frame: frameRect)
-    setup()
-  }
-
-  required init?(coder: NSCoder) {
-    super.init(coder: coder)
-    setup()
-  }
-
-  func setup() {
+class ColorCodeView: LabelView {
+  override func setup() {
     drawsBackground = false
     isBezeled = false
     isBordered = false
     isEditable = false
     font = NSFont(name: Fonts.colorCodeFont, size: 0)
+    backgroundWasLight = Date().asColor().isLight
   }
 
   func update() {
     let date = Date()
+    let dateColor = date.asColor()
     stringValue = date.asHexColorString()
 
-    fade(to: date.asColor().appropriateBlackOrWhite())
+    if dateColor.isLight != backgroundWasLight  {
+      fade(to: dateColor.appropriateBlackOrWhite())
+    }
+    backgroundWasLight = dateColor.isLight
   }
 
   func resizeFont(for size: NSSize) {
     let newFontSize = size.width * 0.0212
     font = NSFont(name: Fonts.colorCodeFont, size: newFontSize)
-  }
-
-  func fade(to toColor: NSColor) {
-    guard let textColor = textColor else { return }
-    var stepCount: CGFloat = 1
-    let fromColor = textColor
-
-    Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true) { (timer) in
-      let fraction = stepCount / CGFloat(20)
-
-      if fraction >= 1 {
-        timer.invalidate()
-      }
-      self.textColor = fromColor.blended(withFraction: CGFloat(fraction),
-                                         of: toColor)
-      stepCount += 1
-    }
   }
 }

--- a/ColorClockSaver/ColorCodeView.swift
+++ b/ColorClockSaver/ColorCodeView.swift
@@ -20,7 +20,14 @@ class ColorCodeView: NSTextField {
   }
 
   func update() {
-    stringValue = Date().asHexColorString()
+    let date = Date()
+    stringValue = date.asHexColorString()
+
+    if date.asColor().isLight {
+      textColor = .black
+    } else {
+      textColor = .white
+    }
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/LabelView.swift
+++ b/ColorClockSaver/LabelView.swift
@@ -1,0 +1,41 @@
+import Cocoa
+
+class LabelView: NSTextField {
+  var frameCount: CGFloat = 1
+  var startColor = NSColor.black
+  var endColor = NSColor.black
+  var backgroundWasLight = false
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    setup()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setup()
+  }
+
+  func setup() {}
+
+  func fade(to toColor: NSColor) {
+    guard let textColor = textColor else { return }
+    frameCount = 1
+    startColor = textColor
+    endColor = toColor
+
+    Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true, block: step)
+  }
+
+  func step(_ timer: Timer) {
+    let fraction: CGFloat = frameCount / CGFloat(20)
+
+    if fraction >= 1 {
+      timer.invalidate()
+      return
+    }
+
+    textColor = startColor.blended(withFraction: fraction, of: endColor)
+    frameCount += 1
+  }
+}

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -28,8 +28,10 @@ class TimeView: NSTextField {
 
     stringValue = dateString
 
+    NSAnimationContext.beginGrouping()
     NSAnimationContext.current().duration = 0.9
     animator().textColor = date.asColor().appropriateBlackOrWhite()
+    NSAnimationContext.endGrouping()
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -1,54 +1,31 @@
 import Cocoa
 
-class TimeView: NSTextField {
-  override init(frame frameRect: NSRect) {
-    super.init(frame: frameRect)
-    setup()
-  }
-
-  required init?(coder: NSCoder) {
-    super.init(coder: coder)
-    setup()
-  }
-
-  func setup() {
+class TimeView: LabelView {
+  override func setup() {
     drawsBackground = false
     isBezeled = false
     isBordered = false
     isEditable = false
     font = NSFont(name: Fonts.timeFont, size: 0)
+    backgroundWasLight = Date().asColor().isLight
   }
 
   func update() {
     let date = Date()
+    let dateColor = date.asColor()
     let formatter = DateFormatter()
     formatter.dateFormat = "HH:mm:ss"
     let dateString = formatter.string(from: date)
     stringValue = dateString
 
-    fade(to: date.asColor().appropriateBlackOrWhite())
+    if dateColor.isLight != backgroundWasLight  {
+      fade(to: dateColor.appropriateBlackOrWhite())
+    }
+    backgroundWasLight = dateColor.isLight
   }
 
   func resizeFont(for size: NSSize) {
     let newFontSize = size.width * 0.1
     font = NSFont(name: Fonts.timeFont, size: newFontSize)
   }
-
-  func fade(to toColor: NSColor) {
-    guard let textColor = textColor else { return }
-    var stepCount: CGFloat = 1
-    let fromColor = textColor
-
-    Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true) { (timer) in
-      let fraction = stepCount / CGFloat(20)
-
-      if fraction >= 1 {
-        timer.invalidate()
-      }
-      self.textColor = fromColor.blended(withFraction: CGFloat(fraction),
-                                         of: toColor)
-      stepCount += 1
-    }
-  }
 }
-

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -26,6 +26,12 @@ class TimeView: NSTextField {
     let dateString = formatter.string(from: date)
 
     stringValue = dateString
+
+    if date.asColor().isLight {
+      textColor = .black
+    } else {
+      textColor = .white
+    }
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -17,6 +17,7 @@ class TimeView: NSTextField {
     isBordered = false
     isEditable = false
     font = NSFont(name: Fonts.timeFont, size: 0)
+    wantsLayer = true
   }
 
   func update() {
@@ -26,7 +27,9 @@ class TimeView: NSTextField {
     let dateString = formatter.string(from: date)
 
     stringValue = dateString
-    textColor = date.asColor().appropriateBlackOrWhite()
+
+    NSAnimationContext.current().duration = 0.9
+    animator().textColor = date.asColor().appropriateBlackOrWhite()
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -28,13 +28,14 @@ class TimeView: NSTextField {
 
     stringValue = dateString
 
-    guard let layer = layer else {
-      fatalError("Could not find CALayer on TimeView")
-    }
-    let fade = CATransition()
+    let fade = CABasicAnimation(keyPath: "textColor")
+    fade.fromValue = textColor
+    fade.toValue = date.asColor().appropriateBlackOrWhite()
     fade.duration = 0.9
-    layer.add(fade, forKey: nil)
-    textColor = date.asColor().appropriateBlackOrWhite()
+    if let layer = layer {
+      layer.add(fade, forKey: fade.keyPath)
+      textColor = date.asColor().appropriateBlackOrWhite()
+    }
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -8,6 +8,7 @@ class TimeView: LabelView {
     isEditable = false
     font = NSFont(name: Fonts.timeFont, size: 0)
     backgroundWasLight = Date().asColor().isLight
+    textColor = Date().asColor().appropriateBlackOrWhite()
   }
 
   func update() {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -28,10 +28,13 @@ class TimeView: NSTextField {
 
     stringValue = dateString
 
-    NSAnimationContext.beginGrouping()
-    NSAnimationContext.current().duration = 0.9
-    animator().textColor = date.asColor().appropriateBlackOrWhite()
-    NSAnimationContext.endGrouping()
+    guard let layer = layer else {
+      fatalError("Could not find CALayer on TimeView")
+    }
+    let fade = CATransition()
+    fade.duration = 0.9
+    layer.add(fade, forKey: nil)
+    textColor = date.asColor().appropriateBlackOrWhite()
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -26,12 +26,7 @@ class TimeView: NSTextField {
     let dateString = formatter.string(from: date)
 
     stringValue = dateString
-
-    if date.asColor().isLight {
-      textColor = .black
-    } else {
-      textColor = .white
-    }
+    textColor = date.asColor().appropriateBlackOrWhite()
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -26,16 +26,18 @@ class TimeView: NSTextField {
     formatter.dateFormat = "HH:mm:ss"
     let dateString = formatter.string(from: date)
 
-    stringValue = dateString
-
-    let fade = CABasicAnimation(keyPath: "textColor")
-    fade.fromValue = textColor
-    fade.toValue = date.asColor().appropriateBlackOrWhite()
-    fade.duration = 0.9
-    if let layer = layer {
-      layer.add(fade, forKey: fade.keyPath)
-      textColor = date.asColor().appropriateBlackOrWhite()
+    guard let layer = self.layer else {
+      fatalError("Could not find CALayer on TimeView")
     }
+
+    NSAnimationContext.runAnimationGroup({ (context: NSAnimationContext) -> Void in
+      self.stringValue = dateString
+    }, completionHandler: { () -> Void in
+      let fade = CATransition()
+      fade.duration = 0.3
+      layer.add(fade, forKey: nil)
+      self.textColor = date.asColor().appropriateBlackOrWhite()
+    })
   }
 
   func resizeFont(for size: NSSize) {

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -17,7 +17,6 @@ class TimeView: NSTextField {
     isBordered = false
     isEditable = false
     font = NSFont(name: Fonts.timeFont, size: 0)
-    wantsLayer = true
   }
 
   func update() {
@@ -25,23 +24,31 @@ class TimeView: NSTextField {
     let formatter = DateFormatter()
     formatter.dateFormat = "HH:mm:ss"
     let dateString = formatter.string(from: date)
+    stringValue = dateString
 
-    guard let layer = self.layer else {
-      fatalError("Could not find CALayer on TimeView")
-    }
-
-    NSAnimationContext.runAnimationGroup({ (context: NSAnimationContext) -> Void in
-      self.stringValue = dateString
-    }, completionHandler: { () -> Void in
-      let fade = CATransition()
-      fade.duration = 0.3
-      layer.add(fade, forKey: nil)
-      self.textColor = date.asColor().appropriateBlackOrWhite()
-    })
+    fade(to: date.asColor().appropriateBlackOrWhite())
   }
 
   func resizeFont(for size: NSSize) {
     let newFontSize = size.width * 0.1
     font = NSFont(name: Fonts.timeFont, size: newFontSize)
   }
+
+  func fade(to toColor: NSColor) {
+    guard let textColor = textColor else { return }
+    var stepCount: CGFloat = 1
+    let fromColor = textColor
+
+    Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true) { (timer) in
+      let fraction = stepCount / CGFloat(20)
+
+      if fraction >= 1 {
+        timer.invalidate()
+      }
+      self.textColor = fromColor.blended(withFraction: CGFloat(fraction),
+                                         of: toColor)
+      stepCount += 1
+    }
+  }
 }
+

--- a/NSColor.swift
+++ b/NSColor.swift
@@ -20,4 +20,21 @@ extension NSColor {
       return .white
     }
   }
+
+  func rgbaComponents() -> [CGFloat] {
+    var rgba: [CGFloat] = [0, 0, 0, 0]
+    getComponents(&rgba)
+    return rgba
+  }
+
+  func isColorEqual(_ other: NSColor) -> Bool {
+    guard
+      let converted = self.usingColorSpace(.sRGB),
+      let otherConverted = other.usingColorSpace(.sRGB)
+    else {
+      return false
+    }
+
+    return converted.rgbaComponents() == otherConverted.rgbaComponents()
+  }
 }

--- a/NSColor.swift
+++ b/NSColor.swift
@@ -12,4 +12,12 @@ extension NSColor {
   var isLight: Bool {
     return luma >= 0.6
   }
+
+  func appropriateBlackOrWhite() -> NSColor {
+    if isLight {
+      return .black
+    } else {
+      return .white
+    }
+  }
 }

--- a/NSColor.swift
+++ b/NSColor.swift
@@ -1,0 +1,15 @@
+import Cocoa
+
+extension NSColor {
+  var luma: Float {
+    let red = 0.2126 * Float(redComponent)
+    let green = 0.7152 * Float(greenComponent)
+    let blue = 0.0722 * Float(blueComponent)
+
+    return red + blue + green
+  }
+
+  var isLight: Bool {
+    return luma >= 0.6
+  }
+}


### PR DESCRIPTION
This fades the color smoothly from white to black and vice versa as appropriate when the background color would make the text hard to read.

Color lightness is determined by the algorithm near the end of [this blog post](https://robots.thoughtbot.com/closer-look-color-lightness).

After determining if a color `isLight` or not, I created a method to return the appropriate black or white based on that color.

Then the trick was to have the textColor fade between black and white. I made several attempts at this which can been seen in the WIP commits, left in for posterity.

The solution was to use a Timer object to old skool animate the text color over a series of frames. It's the only thing I could get to work and look nice with the hard edges of the font.

Finally, optimization was called for so the text wasn't fading to an identical color a vast majority of the time. I did this by I keeping track of the `isLight` value of the background color. If that color matches the current `isLight` value, then it won't call `fade`. If it is different, the `fade` is called.

I went through many iterations of trying to detect if the color should change or not. I ended up settling on this because it's the only thing I could get to work. My original goal was to compare the view's textColor with the potential new text color generated form the date color. But comparing colors turns out to be difficult. Each color has a color space and some color spaces don't like to be compared. Black and white colors have one of these color spaces. Also, it seems that the textColor on an NSTextField is converted into a color space that doesn't like to be compared either.

All this made it challenging to use textColor in anyway as the check to see if it should be faded to another color. So I kept track of a boolean value instead and called it good enough.