### PR TITLE
Prevent image retention

### DIFF
--- a/ColorClockSaver/ColorCodeView.swift
+++ b/ColorClockSaver/ColorCodeView.swift
@@ -17,7 +17,8 @@ class ColorCodeView: LabelView {
     stringValue = date.asHexColorString()
 
     if dateColor.isLight != backgroundWasLight  {
-      fade(to: dateColor.appropriateBlackOrWhite())
+      let blackOrWhite = dateColor.appropriateBlackOrWhite()
+      fade(to: blackOrWhite.withAlphaComponent(preventBurnInAlpha))
     }
     backgroundWasLight = dateColor.isLight
   }

--- a/ColorClockSaver/Info.plist
+++ b/ColorClockSaver/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Probably Has Bugs Beta 5</string>
+	<string>Probably Has Bugs Beta 6</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Edward Loveall. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/ColorClockSaver/LabelView.swift
+++ b/ColorClockSaver/LabelView.swift
@@ -1,6 +1,8 @@
 import Cocoa
 
 class LabelView: NSTextField {
+  let preventBurnInAlpha: CGFloat = 0.9
+
   var frameCount: CGFloat = 1
   var startColor = NSColor.black
   var endColor = NSColor.black

--- a/ColorClockSaver/TimeView.swift
+++ b/ColorClockSaver/TimeView.swift
@@ -20,7 +20,8 @@ class TimeView: LabelView {
     stringValue = dateString
 
     if dateColor.isLight != backgroundWasLight  {
-      fade(to: dateColor.appropriateBlackOrWhite())
+      let blackOrWhite = dateColor.appropriateBlackOrWhite()
+      fade(to: blackOrWhite.withAlphaComponent(preventBurnInAlpha))
     }
     backgroundWasLight = dateColor.isLight
   }


### PR DESCRIPTION
Doing a bit of reading about image retention, it can be avoided by letting the pixels change even a little bit. So I put a small bit of transparency on the text color so those pixels (especially the colons) would change. This combined with the black-to-white transitions should remove most if not all possibility of screen retention.