### PR TITLE
Fix preferences

### DIFF
--- a/ColorClockSaver/ConfigureSheet.xib
+++ b/ColorClockSaver/ConfigureSheet.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13189.4"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,9 +24,9 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QB0-0I-mR6">
-                        <rect key="frame" x="91" y="59" width="72" height="18"/>
+                        <rect key="frame" x="91" y="59" width="110" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="check" title="12-Hour" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GW3-Z2-7fB">
+                        <buttonCell key="cell" type="check" title="12-Hour Clock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GW3-Z2-7fB">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>

--- a/ColorClockSaver/Settings.swift
+++ b/ColorClockSaver/Settings.swift
@@ -8,6 +8,7 @@ class Settings {
     }
     set(value) {
       defaults.set(value, forKey: "isTwelveHour")
+      defaults.synchronize()
     }
   }
 


### PR DESCRIPTION
**The bug**

When the 12-Hour setting was changed in system preferences, it would appear to change the display in the preview pane, but when you launched the screensaver proper, it wouldn't actually show the change.

**The problem**

I think what was happening was when the preferences are updated, the changes must be synced back to the system. This is especially true for screen savers, I believe, because they are not attached to the same process that changes the preferences. If you don't synchronize, you can get into a situation where you see the preview change, but the screensaver it self does not.

**The fix**

Call `synchronize` on the ScreenSaverDefaults